### PR TITLE
Add CMakeLists.txt for pam module

### DIFF
--- a/src/pam/CMakeLists.txt
+++ b/src/pam/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.21)
+project(pam)
+
+set(CMAKE_CXX_STANDARD 14)
+
+# Find deps
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
+find_package(Boost REQUIRED locale)
+find_package(PAM REQUIRED)
+find_library(INIH_LIBRARY INIReader REQUIRED)
+find_path(INIH_INCLUDE_DIR INIReader.h REQUIRED)
+
+# Configure target for shared lib
+add_library(pam_howdy SHARED main.cc main.hh optional_task.hh)
+target_include_directories(
+  pam_howdy PUBLIC ${Boost_INCLUDE_DIRS} ${PAM_INCLUDE_DIR} ${INIH_INCLUDE_DIR})
+target_link_libraries(pam_howdy ${Boost_LIBRARIES} ${PAM_LIBRARIES} INIReader pthread)
+
+# Output config
+set_property(TARGET pam_howdy PROPERTY PREFIX "") # We don't want "lib" prefix
+install(TARGETS pam_howdy DESTINATION /lib/security/)

--- a/src/pam/cmake/modules/FindPAM.cmake
+++ b/src/pam/cmake/modules/FindPAM.cmake
@@ -1,0 +1,76 @@
+# - Try to find the PAM libraries
+# Once done this will define
+#
+#  PAM_FOUND - system has pam
+#  PAM_INCLUDE_DIR - the pam include directory
+#  PAM_LIBRARIES - libpam library
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+if (PAM_INCLUDE_DIR AND PAM_LIBRARY)
+	# Already in cache, be silent
+	set(PAM_FIND_QUIETLY TRUE)
+endif (PAM_INCLUDE_DIR AND PAM_LIBRARY)
+
+find_path(PAM_INCLUDE_DIR NAMES security/pam_appl.h pam/pam_appl.h)
+find_library(PAM_LIBRARY pam)
+find_library(DL_LIBRARY dl)
+
+if (PAM_INCLUDE_DIR AND PAM_LIBRARY)
+	set(PAM_FOUND TRUE)
+	if (DL_LIBRARY)
+		set(PAM_LIBRARIES ${PAM_LIBRARY} ${DL_LIBRARY})
+	else (DL_LIBRARY)
+		set(PAM_LIBRARIES ${PAM_LIBRARY})
+	endif (DL_LIBRARY)
+
+	if (EXISTS ${PAM_INCLUDE_DIR}/pam/pam_appl.h)
+		# darwin claims to be something special
+		set(HAVE_PAM_PAM_APPL_H 1)
+	endif (EXISTS ${PAM_INCLUDE_DIR}/pam/pam_appl.h)
+
+	if (NOT DEFINED PAM_MESSAGE_CONST)
+		include(CheckCXXSourceCompiles)
+		# XXX does this work with plain c?
+		check_cxx_source_compiles("
+#if ${HAVE_PAM_PAM_APPL_H}+0
+# include <pam/pam_appl.h>
+#else
+# include <security/pam_appl.h>
+#endif
+
+static int PAM_conv(
+	int num_msg,
+	const struct pam_message **msg, /* this is the culprit */
+	struct pam_response **resp,
+	void *ctx)
+{
+	return 0;
+}
+
+int main(void)
+{
+	struct pam_conv PAM_conversation = {
+		&PAM_conv, /* this bombs out if the above does not match */
+		0
+	};
+
+	return 0;
+}
+" PAM_MESSAGE_CONST)
+	endif (NOT DEFINED PAM_MESSAGE_CONST)
+	set(PAM_MESSAGE_CONST ${PAM_MESSAGE_CONST} CACHE BOOL "PAM expects a conversation function with const pam_message")
+
+endif (PAM_INCLUDE_DIR AND PAM_LIBRARY)
+
+if (PAM_FOUND)
+	if (NOT PAM_FIND_QUIETLY)
+		message(STATUS "Found PAM: ${PAM_LIBRARIES}")
+	endif (NOT PAM_FIND_QUIETLY)
+else (PAM_FOUND)
+	if (PAM_FIND_REQUIRED)
+		message(FATAL_ERROR "PAM was not found")
+	endif(PAM_FIND_REQUIRED)
+endif (PAM_FOUND)
+
+mark_as_advanced(PAM_INCLUDE_DIR PAM_LIBRARY DL_LIBRARY PAM_MESSAGE_CONST)


### PR DESCRIPTION
The dependency on Meson seems to be heavy for such a simple lib.

This adds cmake support for building this project, assuming that inireader is installed in system.

The FindPAM.cmake file is from [kwallet-pam](https://github.com/KDE/kwallet-pam/blob/2da16355cbbfd01da881f4d3394a46adb268e9a7/cmake/modules/FindPAM.cmake).